### PR TITLE
Adding $priority to the NormalizersRegistryInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
-## 1.0.0 - Unreleased
+## 2.0.0 - 2023-04-19
+- **High Impact Changes**
+  - Since version **2.0.0**, serializers are registered with names `symfony-json`, `symfony-csv`,
+    `symfony-xml`, `symfony-yaml`. To avoid name conflicts with other serializers.
+  - Since version **2.0.0**, methods `getEncoders`, and `getNormalizers`, of the class
+    `Spiral\Serializer\Symfony\Config\SerializerConfig` returns empty arrays by default. Default **encoders**
+    and **normalizers** are configured in `Spiral\Serializer\Symfony\EncodersRegistry` and
+    `Spiral\Serializer\Symfony\NormalizersRegistry`.
+  - Removed methods `getDefaultEncoders` and `getDefaultNormalizers` in the configuration class
+    `Spiral\Serializer\Symfony\Config\SerializerConfig`.
+- **Other Features**
+  - Added the **priority** parameter to the `register` method of interface
+    `Spiral\Serializer\Symfony\NormalizersRegistryInterface`. This will allow normalizers and denormalizers
+    to be registered in the correct order. Default ones are added with a priority that allows you to add your own
+    between them.
+
+## 1.1.0 - 2023-03-31
+- **Other Features**
+  - Allowed `doctrine/annotations:2.0`
+  - Psalm v5
+
+## 1.0.0 - 2022-09-14
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Make sure that your server is configured with following PHP version and extensions:
 
 - PHP 8.1+
-- Spiral framework ^3.0
+- Spiral framework ^3.7
 - Symfony Serializer Component ^5.4 || ^6.0
 - Symfony PropertyAccess Component ^5.4 || ^6.0
 
@@ -39,6 +39,7 @@ protected const LOAD = [
 > you don't need to register bootloader by yourself.
 
 ## Configuration
+
 The package is already configured by default, use these features only if you need to change the default configuration.
 
 The package provides the ability to configure the `normalizers`, `encoders` and `Symfony\Component\Serializer\Mapping\Loader\LoaderInterface`
@@ -46,6 +47,7 @@ for `Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory` used by 
 
 Create a file `app/config/symfony-serializer.php`.
 Add the `normalizers`, `encoders`, `metadataLoader` parameters. For example:
+
 ```php
 <?php
 
@@ -85,25 +87,44 @@ return [
 ];
 ```
 
+### EncodersRegistry and NormalizersRegistry
+
+The package provides `Spiral\Serializer\Symfony\EncodersRegistryInterface` and
+`Spiral\Serializer\Symfony\NormalizersRegistryInterface`. They contain **encoders** and **normalizers/denormalizers**.
+You can add your own **encoder** or **normalizer/denormalizer** to them by using the `register` method:
+
+```php
+public function boot(
+    NormalizersRegistryInterface $normalizersRegistry,
+    EncodersRegistryInterface $encodersRegistry
+): void {
+    // Add CustomNormalizer before ObjectNormalizer
+    $normalizersRegistry->register(normalizer: new CustomNormalizer(), priority: 699);
+
+    $encodersRegistry->register(new CustomEncoder());
+}
+```
+
 ## Usage
+
 Using with `Spiral\Serializer\SerializerManager`. For example:
 ```php
 use Spiral\Serializer\SerializerManager;
 
 $serializer = $this->container->get(SerializerManager::class);
 
-$result = $manager->serialize($payload, 'json');
-$result = $manager->serialize($payload, 'csv');
-$result = $manager->serialize($payload, 'xml');
-$result = $manager->serialize($payload, 'yaml');
+$result = $manager->serialize($payload, 'symfony-json');
+$result = $manager->serialize($payload, 'symfony-csv');
+$result = $manager->serialize($payload, 'symfony-xm');
+$result = $manager->serialize($payload, 'symfony-yaml');
 
-$result = $manager->unserialize($payload, Post::class, 'json');
-$result = $manager->unserialize($payload, Post::class, 'csv');
-$result = $manager->unserialize($payload, Post::class, 'xml');
-$result = $manager->unserialize($payload, Post::class, 'yaml');
+$result = $manager->unserialize($payload, Post::class, 'symfony-json');
+$result = $manager->unserialize($payload, Post::class, 'symfony-csv');
+$result = $manager->unserialize($payload, Post::class, 'symfony-xm');
+$result = $manager->unserialize($payload, Post::class, 'symfony-yaml');
 
 // Getting a serializer `Spiral\Serializer\Symfony\Serializer`
-$serializer = $manager->getSerializer('json');
+$serializer = $manager->getSerializer('symfony-json');
 
 // $serializer->serialize($payload, $context);
 // $serializer->unserialize($payload, $type, $context);
@@ -122,21 +143,20 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 $serializer = $this->container->get(SerializerInterface::class);
 
-$result = $serializer->serialize($payload, 'json', $context);
-$result = $serializer->serialize($payload, 'csv', $context);
-$result = $serializer->serialize($payload, 'xml', $context);
-$result = $serializer->serialize($payload, 'yaml', $context);
+$result = $serializer->serialize($payload, 'symfony-json', $context);
+$result = $serializer->serialize($payload, 'symfony-csv', $context);
+$result = $serializer->serialize($payload, 'symfony-xm', $context);
+$result = $serializer->serialize($payload, 'symfony-yaml', $context);
 
-$result = $serializer->deserialize($payload, Post::class, 'json', $context);
-$result = $serializer->deserialize($payload, Post::class, 'csv', $context);
-$result = $serializer->deserialize($payload, Post::class, 'xml', $context);
-$result = $serializer->deserialize($payload, Post::class, 'yaml', $context);
+$result = $serializer->deserialize($payload, Post::class, 'symfony-json', $context);
+$result = $serializer->deserialize($payload, Post::class, 'symfony-csv', $context);
+$result = $serializer->deserialize($payload, Post::class, 'symfony-xm', $context);
+$result = $serializer->deserialize($payload, Post::class, 'symfony-yaml', $context);
 ```
 
 > **Note**
 > The `yaml` encoder requires the `symfony/yaml` package and is disabled when the package is not installed.
 > Install the `symfony/yaml` package and the encoder will be automatically enabled.
-
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,19 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "spiral/boot": "^3.0",
+        "spiral/boot": "^3.7",
+        "spiral/core": "^3.7",
+        "spiral/config": "^3.7",
         "doctrine/annotations": "^1.12 || ^2.0",
-        "spiral/serializer": "^3.0",
+        "spiral/serializer": "^3.7",
         "symfony/serializer": "^5.4 || ^6.0",
         "symfony/property-access": "^5.4 || ^6.0"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-latest",
-        "phpunit/phpunit": "^9.5.20",
-        "spiral/testing": "^2.0",
+        "phpunit/phpunit": "^10.1",
+        "spiral/testing": "^3.0",
         "symfony/yaml": "^5.4 || ^6.0",
-        "vimeo/psalm": "^5.8"
+        "vimeo/psalm": "^5.9"
     },
     "suggest": {
         "symfony/yaml": "For using the YamlEncoder."

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true" verbose="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+         colors="true"
          processIsolation="false"
          stopOnFailure="false"
          stopOnError="false"
-         stderr="true">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">app/src</directory>
-    </include>
-  </coverage>
+         stderr="true"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+  <coverage/>
   <testsuites>
-    <testsuite name="Symfony serializer Bridge Test Suite">
+    <testsuite name="Symfony Serializer Bridge Test Suite">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">app/src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,15 +10,21 @@
          stderr="true"
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false">
-  <coverage/>
-  <testsuites>
-    <testsuite name="Symfony Serializer Bridge Test Suite">
-      <directory>./tests/</directory>
-    </testsuite>
-  </testsuites>
-  <source>
-    <include>
-      <directory suffix=".php">app/src</directory>
-    </include>
-  </source>
+    <testsuites>
+        <testsuite name="Symfony Serializer Bridge Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Config/SerializerConfig.php
+++ b/src/Config/SerializerConfig.php
@@ -6,12 +6,8 @@ namespace Spiral\Serializer\Symfony\Config;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\Messenger\Transport\Serialization\Normalizer\FlattenExceptionNormalizer;
-use Symfony\Component\Serializer\Encoder;
-use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
-use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
-use Symfony\Component\Serializer\Normalizer;
 use Spiral\Core\InjectableConfig;
 
 final class SerializerConfig extends InjectableConfig
@@ -28,56 +24,15 @@ final class SerializerConfig extends InjectableConfig
      */
     public function getEncoders(): array
     {
-        return $this->config['encoders'] === [] ? $this->getDefaultEncoders() : $this->config['encoders'];
+        return $this->config['encoders'] ?? [];
     }
 
     /**
      * Get registered normalizers.
      */
-    public function getNormalizers(bool $isProduction): array
+    public function getNormalizers(): array
     {
-        return $this->config['normalizers'] === [] ?
-            $this->getDefaultNormalizers($isProduction) :
-            $this->config['normalizers'];
-    }
-
-    public function getDefaultEncoders(): array
-    {
-        return [
-            new Encoder\JsonEncoder(),
-            new Encoder\CsvEncoder(),
-            new Encoder\XmlEncoder(),
-            new Encoder\YamlEncoder(),
-        ];
-    }
-
-    public function getDefaultNormalizers(bool $isProduction): array
-    {
-        $factory = new ClassMetadataFactory($this->getMetadataLoader());
-
-        $normalizers = [
-            new Normalizer\UnwrappingDenormalizer(),
-            new Normalizer\ProblemNormalizer(debug: $isProduction === false),
-            new Normalizer\UidNormalizer(),
-            new Normalizer\JsonSerializableNormalizer(),
-            new Normalizer\DateTimeNormalizer(),
-            new Normalizer\ConstraintViolationListNormalizer(),
-            new Normalizer\MimeMessageNormalizer(new Normalizer\PropertyNormalizer()),
-            new Normalizer\DateTimeZoneNormalizer(),
-            new Normalizer\DateIntervalNormalizer(),
-            new Normalizer\FormErrorNormalizer(),
-            new Normalizer\BackedEnumNormalizer(),
-            new Normalizer\DataUriNormalizer(),
-            new Normalizer\ArrayDenormalizer(),
-            new Normalizer\ObjectNormalizer($factory, new MetadataAwareNameConverter($factory))
-        ];
-
-        // Normalizer from symfony/messenger, if exists
-        if (\class_exists(FlattenExceptionNormalizer::class)) {
-            $normalizers[] = new FlattenExceptionNormalizer();
-        }
-
-        return $normalizers;
+        return $this->config['normalizers'] ?? [];
     }
 
     public function getMetadataLoader(): LoaderInterface

--- a/src/NormalizersRegistry.php
+++ b/src/NormalizersRegistry.php
@@ -4,41 +4,100 @@ declare(strict_types=1);
 
 namespace Spiral\Serializer\Symfony;
 
+use Spiral\Boot\Environment\DebugMode;
+use Symfony\Component\Messenger\Transport\Serialization\Normalizer\FlattenExceptionNormalizer;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer;
 
 class NormalizersRegistry implements NormalizersRegistryInterface
 {
+    /**
+     * @var array<class-string, array{priority: int<0, max>, normalizer: NormalizerInterface|DenormalizerInterface}>
+     */
     private array $normalizers = [];
 
-    public function __construct(array $normalizers = [])
-    {
-        foreach ($normalizers as $normalizer) {
-            $this->register($normalizer);
+    public function __construct(
+        protected readonly LoaderInterface $loader,
+        protected readonly DebugMode $debugMode,
+        array $normalizers = []
+    ) {
+        if ($normalizers === []) {
+            $this->registerDefaultNormalizers();
+        } else {
+            foreach ($normalizers as $normalizer) {
+                $this->register($normalizer);
+            }
         }
     }
 
-    public function register(NormalizerInterface|DenormalizerInterface $normalizer): void
+    /**
+     * @param int<0, max> $priority
+     */
+    public function register(NormalizerInterface|DenormalizerInterface $normalizer, int $priority = 0): void
     {
         if (!$this->has($normalizer::class)) {
-            $this->normalizers[] = $normalizer;
+            $this->normalizers[$normalizer::class] = [
+                'priority' => $priority,
+                'normalizer' => $normalizer
+            ];
         }
     }
 
+    /**
+     * @return array<NormalizerInterface|DenormalizerInterface>
+     */
     public function all(): array
     {
-        return $this->normalizers;
+        // Sort normalizers by priority
+        \uasort(
+            $this->normalizers,
+            static fn (array $normalizer1, array $normalizer2) => $normalizer1['priority'] <=> $normalizer2['priority']
+        );
+
+        return \array_column($this->normalizers, 'normalizer');
     }
 
     /** @psalm-param class-string $className */
     public function has(string $className): bool
     {
-        foreach ($this->normalizers as $normalizer) {
-            if ($className === $normalizer::class) {
-                return true;
-            }
-        }
+        return isset($this->normalizers[$className]);
+    }
 
-        return false;
+    private function registerDefaultNormalizers(): void
+    {
+        $factory = new ClassMetadataFactory($this->loader);
+
+        $this->register(new Normalizer\UnwrappingDenormalizer(), 50);
+        $this->register(new Normalizer\ProblemNormalizer(debug: $this->debugMode->isEnabled()), 100);
+        $this->register(new Normalizer\UidNormalizer(), 150);
+        $this->register(new Normalizer\JsonSerializableNormalizer(), 200);
+        $this->register(new Normalizer\DateTimeNormalizer(), 250);
+        $this->register(new Normalizer\ConstraintViolationListNormalizer(), 300);
+        $this->register(new Normalizer\MimeMessageNormalizer(new Normalizer\PropertyNormalizer()), 350);
+        $this->register(new Normalizer\DateTimeZoneNormalizer(), 400);
+        $this->register(new Normalizer\DateIntervalNormalizer(), 450);
+        $this->register(new Normalizer\FormErrorNormalizer(), 500);
+        $this->register(new Normalizer\BackedEnumNormalizer(), 550);
+        $this->register(new Normalizer\DataUriNormalizer(), 600);
+        $this->register(new Normalizer\ArrayDenormalizer(), 650);
+        $this->register(new Normalizer\ObjectNormalizer(
+            classMetadataFactory: $factory,
+            nameConverter: new MetadataAwareNameConverter($factory),
+            propertyTypeExtractor: new PropertyInfoExtractor(
+                typeExtractors: [new PhpDocExtractor(), new ReflectionExtractor()]
+            )
+        ), 700);
+
+        // Normalizer from symfony/messenger, if exists
+        if (\class_exists(FlattenExceptionNormalizer::class)) {
+            $this->register(new FlattenExceptionNormalizer(), 750);
+        }
     }
 }

--- a/src/NormalizersRegistryInterface.php
+++ b/src/NormalizersRegistryInterface.php
@@ -9,7 +9,10 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 interface NormalizersRegistryInterface
 {
-    public function register(NormalizerInterface|DenormalizerInterface $normalizer): void;
+    /**
+     * @param int<0, max> $priority
+     */
+    public function register(NormalizerInterface|DenormalizerInterface $normalizer, int $priority = 0): void;
 
     public function all(): array;
 

--- a/tests/app/NestedObjects/City.php
+++ b/tests/app/NestedObjects/City.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spiral\Serializer\Symfony\Tests\App\NestedObjects;
+
+final class City implements \JsonSerializable
+{
+    public function __construct(
+        public string $name,
+        public \DateTimeZone $timezone,
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'timezone' => $this->timezone->getName(),
+        ];
+    }
+}

--- a/tests/app/NestedObjects/Country.php
+++ b/tests/app/NestedObjects/Country.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spiral\Serializer\Symfony\Tests\App\NestedObjects;
+
+final class Country
+{
+    /**
+     * @param non-empty-string $name
+     * @param City[] $cities
+     */
+    public function __construct(
+        public string $name,
+        public array $cities,
+    ) {
+    }
+}

--- a/tests/src/Feature/Bootloader/SerializerBootloaderTest.php
+++ b/tests/src/Feature/Bootloader/SerializerBootloaderTest.php
@@ -12,9 +12,6 @@ use Spiral\Serializer\Symfony\NormalizersRegistry;
 use Spiral\Serializer\Symfony\NormalizersRegistryInterface;
 use Spiral\Serializer\Symfony\Serializer;
 use Spiral\Serializer\Symfony\Tests\Feature\TestCase;
-use Symfony\Component\Serializer\Encoder\EncoderInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class SerializerBootloaderTest extends TestCase
 {
@@ -33,25 +30,19 @@ final class SerializerBootloaderTest extends TestCase
         $config = $this->getConfig(SerializerConfig::CONFIG);
 
         $this->assertIsArray($config['normalizers']);
-        $this->assertCount(14, $config['normalizers']);
-        foreach ($config['normalizers'] as $normalizer) {
-            $this->assertTrue($normalizer instanceof NormalizerInterface || $normalizer instanceof DenormalizerInterface);
-        }
+        $this->assertSame([], $config['normalizers']);
 
         $this->assertIsArray($config['encoders']);
-        $this->assertCount(4, $config['encoders']);
-        foreach ($config['encoders'] as $encoder) {
-            $this->assertInstanceOf(EncoderInterface::class, $encoder);
-        }
+        $this->assertSame([], $config['encoders']);
     }
 
     public function testSerializerIsConfigured(): void
     {
         $manager = $this->getContainer()->get(SerializerManager::class);
 
-        $this->assertInstanceOf(Serializer::class, $manager->getSerializer('json'));
-        $this->assertInstanceOf(Serializer::class, $manager->getSerializer('csv'));
-        $this->assertInstanceOf(Serializer::class, $manager->getSerializer('xml'));
-        $this->assertInstanceOf(Serializer::class, $manager->getSerializer('yaml'));
+        $this->assertInstanceOf(Serializer::class, $manager->getSerializer('symfony-json'));
+        $this->assertInstanceOf(Serializer::class, $manager->getSerializer('symfony-csv'));
+        $this->assertInstanceOf(Serializer::class, $manager->getSerializer('symfony-xml'));
+        $this->assertInstanceOf(Serializer::class, $manager->getSerializer('symfony-yaml'));
     }
 }

--- a/tests/src/Unit/EncodersRegistryTest.php
+++ b/tests/src/Unit/EncodersRegistryTest.php
@@ -6,34 +6,51 @@ namespace Spiral\Serializer\Symfony\Tests\Unit;
 
 use Spiral\Serializer\Symfony\EncodersRegistry;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
 
 final class EncodersRegistryTest extends TestCase
 {
-    public function testConstruct(): void
+    public function testConstructWithDefaultEncoders(): void
     {
-        $this->assertCount(0, (new EncodersRegistry())->all());
+        $registry = new EncodersRegistry();
 
-        $registry = new EncodersRegistry([new JsonEncoder(), new CsvEncoder()]);
-        $this->assertCount(2, $registry->all());
+        $this->assertCount(4, $registry->all());
+
         $this->assertTrue($registry->has(JsonEncoder::class));
         $this->assertTrue($registry->has(CsvEncoder::class));
+        $this->assertTrue($registry->has(XmlEncoder::class));
+        $this->assertTrue($registry->has(YamlEncoder::class));
+    }
+
+    public function testConstructWithEncoders(): void
+    {
+        $registry = new EncodersRegistry([new JsonEncoder(), new CsvEncoder()]);
+
+        $this->assertCount(2, $registry->all());
+
+        $this->assertTrue($registry->has(JsonEncoder::class));
+        $this->assertTrue($registry->has(CsvEncoder::class));
+        $this->assertFalse($registry->has(XmlEncoder::class));
+        $this->assertFalse($registry->has(YamlEncoder::class));
     }
 
     public function testRegister(): void
     {
         $registry = new EncodersRegistry();
 
-        $registry->register(new JsonEncoder());
-        $this->assertCount(1, $registry->all());
-        $this->assertTrue($registry->has(JsonEncoder::class));
+        $encoder = $this->createMock(EncoderInterface::class);
 
-        $registry->register(new JsonEncoder());
-        $this->assertCount(1, $registry->all());
+        $this->assertCount(4, $registry->all());
+        $registry->register($encoder);
+        $this->assertCount(5, $registry->all());
+        $this->assertTrue($registry->has($encoder::class));
 
-        $registry->register(new CsvEncoder());
-        $this->assertCount(2, $registry->all());
-        $this->assertTrue($registry->has(CsvEncoder::class));
+        $registry->register($encoder);
+        $this->assertCount(5, $registry->all());
+        $this->assertTrue($registry->has($encoder::class));
     }
 
     public function testAll(): void
@@ -41,18 +58,18 @@ final class EncodersRegistryTest extends TestCase
         $json = new JsonEncoder();
         $csv = new CsvEncoder();
 
-        $this->assertSame([], (new EncodersRegistry())->all());
-
         $registry = new EncodersRegistry([$json, $csv]);
         $this->assertSame([$json, $csv], $registry->all());
     }
 
     public function testHas(): void
     {
-        $registry = new EncodersRegistry();
-        $this->assertFalse($registry->has(JsonEncoder::class));
+        $encoder = $this->createMock(EncoderInterface::class);
 
-        $registry->register(new JsonEncoder());
-        $this->assertTrue($registry->has(JsonEncoder::class));
+        $registry = new EncodersRegistry();
+        $this->assertFalse($registry->has($encoder::class));
+
+        $registry->register($encoder);
+        $this->assertTrue($registry->has($encoder::class));
     }
 }

--- a/tests/src/Unit/NormalizersRegistryTest.php
+++ b/tests/src/Unit/NormalizersRegistryTest.php
@@ -4,55 +4,85 @@ declare(strict_types=1);
 
 namespace Spiral\Serializer\Symfony\Tests\Unit;
 
+use Spiral\Boot\Environment\DebugMode;
 use Spiral\Serializer\Symfony\NormalizersRegistry;
-use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
-use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Serializer\Normalizer;
 
 final class NormalizersRegistryTest extends TestCase
 {
-    public function testConstruct(): void
+    public function testConstructWithDefaultNormalizers(): void
     {
-        $this->assertCount(0, (new NormalizersRegistry())->all());
+        $registry = new NormalizersRegistry(
+            $this->createMock(LoaderInterface::class),
+            DebugMode::Enabled
+        );
 
-        $registry = new NormalizersRegistry([new UnwrappingDenormalizer(), new ObjectNormalizer()]);
-        $this->assertCount(2, $registry->all());
-        $this->assertTrue($registry->has(UnwrappingDenormalizer::class));
-        $this->assertTrue($registry->has(ObjectNormalizer::class));
+        $this->assertCount(14, $registry->all());
+
+        $this->assertTrue($registry->has(Normalizer\UnwrappingDenormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\ProblemNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\UidNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\JsonSerializableNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\DateTimeNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\ConstraintViolationListNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\MimeMessageNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\DateTimeZoneNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\DateIntervalNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\FormErrorNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\BackedEnumNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\DataUriNormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\ArrayDenormalizer::class));
+        $this->assertTrue($registry->has(Normalizer\ObjectNormalizer::class));
     }
 
     public function testRegister(): void
     {
-        $registry = new NormalizersRegistry();
+        $registry = new NormalizersRegistry(
+            $this->createMock(LoaderInterface::class),
+            DebugMode::Enabled
+        );
 
-        $registry->register(new UnwrappingDenormalizer());
-        $this->assertCount(1, $registry->all());
-        $this->assertTrue($registry->has(UnwrappingDenormalizer::class));
+        $normalizer = $this->createMock(Normalizer\NormalizerInterface::class);
+        $normalizer2 = $this->createMock(Normalizer\DenormalizerInterface::class);
 
-        $registry->register(new UnwrappingDenormalizer());
-        $this->assertCount(1, $registry->all());
+        $registry->register($normalizer, 2);
+        $this->assertCount(15, $registry->all());
+        $this->assertTrue($registry->has($normalizer::class));
 
-        $registry->register(new ObjectNormalizer());
-        $this->assertCount(2, $registry->all());
-        $this->assertTrue($registry->has(ObjectNormalizer::class));
+        $registry->register($normalizer2, 1);
+        $this->assertCount(16, $registry->all());
+        $this->assertTrue($registry->has($normalizer2::class));
+
+        $this->assertSame($normalizer2, $registry->all()[0]);
+        $this->assertSame($normalizer, $registry->all()[1]);
     }
 
     public function testAll(): void
     {
-        $unwrapping = new UnwrappingDenormalizer();
-        $object = new ObjectNormalizer();
+        $unwrapping = new Normalizer\UnwrappingDenormalizer();
+        $object = new Normalizer\ObjectNormalizer();
 
-        $this->assertSame([], (new NormalizersRegistry())->all());
+        $registry = new NormalizersRegistry(
+            $this->createMock(LoaderInterface::class),
+            DebugMode::Enabled,
+            [$unwrapping, $object]
+        );
 
-        $registry = new NormalizersRegistry([$unwrapping, $object]);
         $this->assertSame([$unwrapping, $object], $registry->all());
     }
 
     public function testHas(): void
     {
-        $registry = new NormalizersRegistry();
-        $this->assertFalse($registry->has(UnwrappingDenormalizer::class));
+        $normalizer = $this->createMock(Normalizer\NormalizerInterface::class);
 
-        $registry->register(new UnwrappingDenormalizer());
-        $this->assertTrue($registry->has(UnwrappingDenormalizer::class));
+        $registry = new NormalizersRegistry(
+            $this->createMock(LoaderInterface::class),
+            DebugMode::Enabled
+        );
+        $this->assertFalse($registry->has($normalizer::class));
+
+        $registry->register($normalizer);
+        $this->assertTrue($registry->has($normalizer::class));
     }
 }


### PR DESCRIPTION
### Features

1) Added the **priority** parameter to the `register` method of the interface
    `Spiral\Serializer\Symfony\NormalizersRegistryInterface`. This will allow normalizers and denormalizers
    to be registered in the correct order. Default ones are added with a priority that allows you to add your own
    between them.

```php
// add custom normalizer BEFORE all default normalizers
$registry->register(new CustomNormalizer(), 1);
```

### Bugfixes

1) Fixed nested objects serialization.