### PR TITLE
Implementing getSupportedTypes

### DIFF
--- a/src/Normalizer/RamseyUuidNormalizer.php
+++ b/src/Normalizer/RamseyUuidNormalizer.php
@@ -41,4 +41,11 @@ final class RamseyUuidNormalizer implements NormalizerInterface, DenormalizerInt
     {
         return \is_string($data) && \is_a($type, UuidInterface::class, true) && Uuid::isValid($data);
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            UuidInterface::class => true,
+        ];
+    }
 }


### PR DESCRIPTION
This is required since SF 6.3 (deprecation warning)